### PR TITLE
Friends data column selector fix

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -513,7 +513,7 @@ class FriendsProcessor(DataProcessor):
       # We take out our header in each dataset
       if i == 0:
         id_header_index = line.index("")
-        dialogue_header_index = line.index("dialogue")
+        dialogue_header_index = line.index("utterance")
         annotation_header_index = line.index("annotation")
         emotion_header_index = line.index("emotion")
         act_header_index = line.index("act")
@@ -568,7 +568,7 @@ class FriendsContextProcessor(DataProcessor):
       # We take out our header in each dataset
       if i == 0:
         id_header_index = line.index("")
-        dialogue_header_index = line.index("dialogue")
+        dialogue_header_index = line.index("utterance")
         annotation_header_index = line.index("annotation")
         emotion_header_index = line.index("emotion")
         act_header_index = line.index("act")


### PR DESCRIPTION
Correct the data selector to select the correct column ("utterance" rather than the non-existent "dialogue" column).
This was caused by copy-pasting this code from the DailyDialogue code.